### PR TITLE
Add HTML escape sequence to the record label

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.11-SNAPSHOT
+version=1.0.12-SNAPSHOT

--- a/graphviz-builder/src/main/java/org/anarres/graphviz/builder/GraphVizRecordLabel.java
+++ b/graphviz-builder/src/main/java/org/anarres/graphviz/builder/GraphVizRecordLabel.java
@@ -28,6 +28,9 @@ public class GraphVizRecordLabel {
     private static final Escaper ESCAPE_MINIMAL = Escapers.builder()
             .addEscape('\n', "<BR/>")
             .addEscape('\r', "")
+            .addEscape('<', "&lt;")
+            .addEscape('>', "&gt;")
+            .addEscape('&', "&amp;")
             .build();
 
     private static String E(@Nonnull GraphVizLabel in) {


### PR DESCRIPTION
When GraphVizRecordLabel calls getBuffer on the GraphVizLabel it is not
escaped and GraphVizRecordLabel adds minimal escape sequence, causing
problem when it has special characters like &, < etc.